### PR TITLE
Update of packages and use the new constructor for RecyclableMemoryStreamManager

### DIFF
--- a/Benchmarks/JwtUtils.Benchmarks/JwtUtils.Benchmarks.csproj
+++ b/Benchmarks/JwtUtils.Benchmarks/JwtUtils.Benchmarks.csproj
@@ -16,9 +16,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
-      <PackageReference Include="JWT" Version="10.1.0" />
-      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.0" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+      <PackageReference Include="JWT" Version="10.1.1" />
+      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/JwtUtils/Header.cs
+++ b/JwtUtils/Header.cs
@@ -17,13 +17,18 @@ internal class Header
     private const int MaximumFreeLargePoolBytes = MaximumBufferSize * 4;
     private const int MaximumFreeSmallPoolBytes = 250 * BlockSize;
     
-    private static readonly RecyclableMemoryStreamManager PoolManager = new(BlockSize, LargeBufferMultiple, MaximumBufferSize)
-    { 
+    private static readonly RecyclableMemoryStreamManager.Options Options = new(
+        BlockSize, 
+        LargeBufferMultiple, 
+        MaximumBufferSize, 
+        MaximumFreeLargePoolBytes, 
+        MaximumFreeSmallPoolBytes)
+    {
         AggressiveBufferReturn = true,
-        GenerateCallStacks = false,
-        MaximumFreeLargePoolBytes = MaximumFreeLargePoolBytes,
-        MaximumFreeSmallPoolBytes = MaximumFreeSmallPoolBytes
-    }; 
+        GenerateCallStacks = false
+    };
+    
+    private static readonly RecyclableMemoryStreamManager PoolManager = new(Options); 
     
     /// <summary>
     /// Create fixed for web JwtHeader
@@ -42,7 +47,7 @@ internal class Header
 
             long dataLength;
             
-            using (var jsonWriter = new Utf8JsonWriter(pooledOutputStream))
+            using (var jsonWriter = new Utf8JsonWriter((IBufferWriter<byte>)pooledOutputStream))
             {
                 jsonWriter.WriteStartObject();
                     

--- a/JwtUtils/JwtUtils.csproj
+++ b/JwtUtils/JwtUtils.csproj
@@ -21,8 +21,8 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
-      <PackageReference Include="System.Text.Json" Version="7.0.3" />
+      <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
+      <PackageReference Include="System.Text.Json" Version="8.0.1" />
     </ItemGroup>
     
     <ItemGroup>

--- a/Tests/JwtUtils.Tests/JwtUtils.Tests.csproj
+++ b/Tests/JwtUtils.Tests/JwtUtils.Tests.csproj
@@ -8,13 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-        <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.console" Version="2.5.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="xunit" Version="2.6.6" />
+        <PackageReference Include="xunit.runner.console" Version="2.6.6">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
This pull request is about updating JwtUtils to the last version of Microsoft.IO.RecyclableMemoryStream (3.0.0), because a breaking change has been made in the constructors of RecyclableMemoryStreamManager, and the one that was used has been removed. The current version of JwtUtil is throwing a MissingMethodException in one of my project because of this.

I also updated the other packages while at it.
